### PR TITLE
Add instructions and configmaps for injecting dikastes sidecar.

### DIFF
--- a/config/install/README-injector-configmap.MD
+++ b/config/install/README-injector-configmap.MD
@@ -1,0 +1,47 @@
+# How to inject additional sidecar containers and volumes with Istio
+Istio: 0.5.1
+[Istio Instructions](https://istio.io/docs/setup/kubernetes/sidecar-injection.html)
+
+## Use the injector configmap
+* To inject Dikastes side car in the application pods use `istio-dikastes-sidecar-injector-configmap-release.yaml` or
+`istio-dikastes-sidecar-injector-configmap-debug.yaml`
+
+## Manual Injection
+* Extract the injection configuration
+```
+kubectl create -f config/install/istio-dikastes-sidecar-injector-configmap-release.yaml \
+    --dry-run \
+    -o=jsonpath='{.data.config}' > inject-config.yaml
+```
+
+* Use the updated inject-config.yaml to manually launch application
+```
+istioctl kube-inject \
+    --injectConfigFile inject-config.yaml \
+    --filename samples/sleep/sleep.yaml \
+    --output sleep-injected.yaml
+    
+kubectl apply -f sleep-injected.yaml    
+```
+
+## Webhook Injection
+
+Inject the configmap specified here
+```
+kubectl apply -f config/install/istio-dikastes-sidecar-injector-configmap-release.yaml
+```
+
+Then follow the instructions to setup the [webhook](https://istio.io/docs/setup/kubernetes/sidecar-injection.html#installing-the-webhook)
+
+## Launch and verify that pod's are launched with additional containers
+```
+~/istio-0.5.1$ kubectl create -f samples/sleep/sleep.yaml
+```
+
+Confirm that the sleep pod is running with __3__ containers (Envoy sidecar, dikastes-sidecar and the sleep container)
+```
+$ kubectl get pods
+NAME                     READY     STATUS    RESTARTS   AGE
+nodeagent-fxlnb          1/1       Running   3          1h
+sleep-776b7bcdcd-7nvp9   3/3       Running   0          7s
+```

--- a/config/install/istio-dikastes-sidecar-injector-configmap-debug.yaml
+++ b/config/install/istio-dikastes-sidecar-injector-configmap-debug.yaml
@@ -1,0 +1,123 @@
+# GENERATED FILE. Use with Kubernetes 1.9+
+# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh
+## For Istio Release: 0.5.1
+kind: ConfigMap
+metadata:
+  name: istio-inject
+  namespace: istio-system
+apiVersion: v1
+data:
+  config: |
+    policy: enabled
+    template: |-
+      initContainers:
+      - name: istio-init
+        image: docker.io/istio/proxy_init:0.5.1
+        args:
+        - "-p"
+        - {{ .MeshConfig.ProxyListenPort }}
+        - "-u"
+        - 1337
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        restartPolicy: Always
+      - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
+          unlimited
+        command:
+        - /bin/sh
+        image: alpine
+        imagePullPolicy: IfNotPresent
+        name: enable-core-dump
+        resources: {}
+        securityContext:
+          privileged: true
+      containers:
+      - name: istio-proxy
+        image: docker.io/istio/proxy_debug:0.5.1
+        args:
+        - proxy
+        - sidecar
+        - --configPath
+        - {{ .ProxyConfig.ConfigPath }}
+        - --binaryPath
+        - {{ .ProxyConfig.BinaryPath }}
+        - --serviceCluster
+        {{ if ne "" (index .ObjectMeta.Labels "app") -}}
+        - {{ index .ObjectMeta.Labels "app" }}
+        {{ else -}}
+        - "istio-proxy"
+        {{ end -}}
+        - --drainDuration
+        - 2s
+        - --parentShutdownDuration
+        - 3s
+        - --discoveryAddress
+        - {{ .ProxyConfig.DiscoveryAddress }}
+        - --discoveryRefreshDelay
+        - 1s
+        - --zipkinAddress
+        - {{ .ProxyConfig.ZipkinAddress }}
+        - --connectTimeout
+        - 1s
+        - --statsdUdpAddress
+        - {{ .ProxyConfig.StatsdUdpAddress }}
+        - --proxyAdminPort
+        - {{ .ProxyConfig.ProxyAdminPort }}
+        - --controlPlaneAuthPolicy
+        - {{ .ProxyConfig.ControlPlaneAuthPolicy }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        imagePullPolicy: IfNotPresent
+        securityContext:
+            privileged: true
+            readOnlyRootFilesystem: false
+            runAsUser: 1337
+        restartPolicy: Always
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      - name: dikastes-sidecar
+        imagePullPolicy: Always
+        image: quay.io/spikecurtis/dikastes:latest
+        args:
+        - server
+        - --dial
+        - /tmp/udsver/nodeagent/socket
+        volumeMounts:
+          - mountPath: /tmp/udsver
+            name: test-volume
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          {{ if eq .Spec.ServiceAccountName "" -}}
+          secretName: istio.default
+          {{ else -}}
+          secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+          {{ end -}}
+      - name: test-volume
+        flexVolume:
+          driver: nodeagent/uds

--- a/config/install/istio-dikastes-sidecar-injector-configmap-release.yaml
+++ b/config/install/istio-dikastes-sidecar-injector-configmap-release.yaml
@@ -1,0 +1,110 @@
+# GENERATED FILE. Use with Kubernetes 1.9+
+# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh
+## For Istio Release: 0.5.1
+kind: ConfigMap
+metadata:
+  name: istio-inject
+  namespace: istio-system
+apiVersion: v1
+data:
+  config: |
+    policy: enabled
+    template: |-
+      initContainers:
+      - name: istio-init
+        image: docker.io/istio/proxy_init:0.5.1
+        args:
+        - "-p"
+        - {{ .MeshConfig.ProxyListenPort }}
+        - "-u"
+        - 1337
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+        restartPolicy: Always
+      containers:
+      - name: istio-proxy
+        image: docker.io/istio/proxy:0.5.1
+        args:
+        - proxy
+        - sidecar
+        - --configPath
+        - {{ .ProxyConfig.ConfigPath }}
+        - --binaryPath
+        - {{ .ProxyConfig.BinaryPath }}
+        - --serviceCluster
+        {{ if ne "" (index .ObjectMeta.Labels "app") -}}
+        - {{ index .ObjectMeta.Labels "app" }}
+        {{ else -}}
+        - "istio-proxy"
+        {{ end -}}
+        - --drainDuration
+        - 2s
+        - --parentShutdownDuration
+        - 3s
+        - --discoveryAddress
+        - {{ .ProxyConfig.DiscoveryAddress }}
+        - --discoveryRefreshDelay
+        - 1s
+        - --zipkinAddress
+        - {{ .ProxyConfig.ZipkinAddress }}
+        - --connectTimeout
+        - 1s
+        - --statsdUdpAddress
+        - {{ .ProxyConfig.StatsdUdpAddress }}
+        - --proxyAdminPort
+        - {{ .ProxyConfig.ProxyAdminPort }}
+        - --controlPlaneAuthPolicy
+        - {{ .ProxyConfig.ControlPlaneAuthPolicy }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        imagePullPolicy: IfNotPresent
+        securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1337
+        restartPolicy: Always
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      - name: dikastes-sidecar
+        imagePullPolicy: Always
+        image: quay.io/spikecurtis/dikastes:latest
+        args:
+        - server
+        - --dial
+        - /tmp/udsver/nodeagent/socket
+        volumeMounts:
+        - mountPath: /tmp/udsver
+          name: test-volume
+      volumes:
+      - flexVolume:
+          driver: nodeagent/uds
+        name: test-volume
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          {{ if eq .Spec.ServiceAccountName "" -}}
+          secretName: istio.default
+          {{ else -}}
+          secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+          {{ end -}}


### PR DESCRIPTION
_Title_
Added `injection-configmap` with dikastes sidecar container and required volume appended to the configmap.
The configmap can then be used with either manual or webhook istio sidecar injection method.
Also added a README with instructions on how to use the configmap(s).

_Testing_
Tested with a dummy sidecar to confirm that the additional sidecar and volume are added as sidecars.
Testing with Dikastes+Felix is TBD